### PR TITLE
Update jest-environment-knex.ts

### DIFF
--- a/src/jest-environment-knex.ts
+++ b/src/jest-environment-knex.ts
@@ -21,7 +21,7 @@ export default class KnexEnvironment extends NodeEnvironment {
   private destroyPromises: any = [];
   private options: Knex.Config;
 
-  constructor(config: Config.ProjectConfig) {
+  constructor(config: Config) {
     super(config);
     debug("super(config)");
 
@@ -41,12 +41,12 @@ export default class KnexEnvironment extends NodeEnvironment {
       Object.assign(this.context, config.testEnvironmentOptions)
     ));
     const prefix =
-      config.testEnvironmentOptions.prefix || "jest_environment_knex";
+      config.projectConfig.testEnvironmentOptions.prefix || "jest_environment_knex";
     global.databaseName = `${prefix}_${uid(16).toLowerCase()}`;
 
     //
 
-    this.options = config.testEnvironmentOptions;
+    this.options = config.projectConfig.testEnvironmentOptions;
   }
 
   public async setup() {


### PR DESCRIPTION
Per https://jestjs.io/docs/28.x/upgrading-to-jest28#custom-environment the Jest custom environment constructor now takes an object as its first argument, containing `{globalConfig, projectConfig}` - previously this was just `projectConfig`.  Jest is now at v29 but this is the only issue I've found so far in upgrading this test environment.